### PR TITLE
Criando partições do kafka corretamente

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       KAFKA_DEFAULT_REPLICATION_FACTOR: 2
       KAFKA_MIN_INSYNC_REPLICAS: 1
       # Disable auto topic creation to enforce explicit partition configuration
-      #KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_NUM_PARTITIONS: 3
     volumes:
       - kafka1_logs:/var/lib/kafka/data/
@@ -54,7 +54,7 @@ services:
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:19092,2@kafka2:19093,3@kafka3:19094
       KAFKA_LOG_DIRS: /var/lib/kafka/data/
       # Disable auto topic creation to enforce explicit partition configuration
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_NUM_PARTITIONS: 3
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
       KAFKA_DEFAULT_REPLICATION_FACTOR: 2
@@ -87,7 +87,7 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       # Disable auto topic creation to enforce explicit partition configuration
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_NUM_PARTITIONS: 3
       # KAFKA_CONTROLLER_QUORUM_VOTERS: <node_id>@<hostname>:<port> -> quem pode votar
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka1:19092,2@kafka2:19093,3@kafka3:19094

--- a/makefile
+++ b/makefile
@@ -180,6 +180,13 @@ recover-consumer:
 
 # Limpa build dos containers
 clean:
+	@echo "Limpando partições antigas..."
+	if docker inspect -f '{{.State.Running}}' kafka1 2>/dev/null | grep -q true; then \
+		docker exec -it kafka1 /opt/kafka/bin/kafka-topics.sh \
+		--delete --topic dados-sensores \
+		--bootstrap-server kafka1:9092; \
+	fi
+
 	@echo "Parando e removendo containers..."
 	make stop
 	@echo "Removendo imagens Docker..."


### PR DESCRIPTION
This pull request updates the Kafka configuration in `docker-compose.yml` to allow automatic topic creation and adds a cleanup step to the `makefile` for easier management of Kafka partitions. These changes streamline local development and testing by reducing manual steps when working with Kafka topics.

Kafka configuration updates:
* Enabled automatic topic creation for all Kafka broker services by setting `KAFKA_AUTO_CREATE_TOPICS_ENABLE` to `"true"` in `docker-compose.yml`. This change makes it easier to work with new topics without needing explicit configuration. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L24-R24) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L57-R57) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L90-R90)

Development workflow improvements:
* Added a cleanup step to the `clean` target in the `makefile` to automatically delete the `dados-sensores` Kafka topic if the `kafka1` container is running, helping prevent issues with old partitions during development.