### PR TITLE
Add restart policy to sensor services and enhance Kafka producer conf…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     build: ./sensor
     ports:
       - "8080:8080"
+    restart: unless-stopped
     depends_on:
       kafka1:
         condition: service_healthy
@@ -137,6 +138,7 @@ services:
     build: ./sensor
     ports:
       - "8081:8081"
+    restart: unless-stopped
     depends_on:
       kafka1:
         condition: service_healthy
@@ -161,6 +163,7 @@ services:
     build: ./sensor
     ports:
       - "8082:8082"
+    restart: unless-stopped
     depends_on:
       kafka1:
         condition: service_healthy

--- a/frontend/app/services/log_service.py
+++ b/frontend/app/services/log_service.py
@@ -178,7 +178,8 @@ class LogService:
 
             startup_indicators = [
                 "Conectado ao Kafka", "Sensor configurado para a partição",
-                "Consumidor iniciado", "atribuído à partição", "recuperado"
+                "Consumidor iniciado", "atribuído à partição", "recuperado",
+                "Mensagem enviada para dados-sensores"
             ]
             shutdown_indicators = ["shutting down", "Shutdown completed", "derrubado"]
             error_indicators = ["FATAL", "EXCEPTION", "Error", "Falha","CONTAINER_REMOVED"]


### PR DESCRIPTION
This pull request introduces reliability improvements to the Kafka producer setup and Docker Compose configuration, as well as updates to the service status detection logic. The main changes focus on making the sensor services more resilient to failures and improving observability.

**Kafka Producer Reliability Enhancements:**

* Added several configuration options to the Kafka producer in `sensor/sensor.py` to ensure message delivery reliability and ordering, including enabling idempotence, setting acknowledgments to "all", limiting in-flight requests, increasing retries, and batching messages.

**Docker Compose Service Resilience:**

* Added `restart: unless-stopped` to all sensor service definitions in `docker-compose.yml` to ensure services automatically restart on failure unless explicitly stopped. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R116) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R141) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R166)

**Service Status Detection Improvements:**

* Updated the `startup_indicators` list in `frontend/app/services/log_service.py` to include "Mensagem enviada para dados-sensores", improving the accuracy of service status detection.

**Minor Refactoring:**

* Moved the creation of the Kafka producer in the main loop of `sensor/sensor.py` to ensure it is instantiated before sending messages, improving code clarity.…iguration