### PR TITLE
Ajustando captura de logs após os containers serem recuperados

### DIFF
--- a/frontend/app/services/log_service.py
+++ b/frontend/app/services/log_service.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 from typing import List, Dict, Optional
 
 class LogService:
@@ -35,6 +36,28 @@ class LogService:
         except Exception as e:
             print(f"Error reading {filename}: {e}")
             return None
+
+    def _is_log_file_stale(self, filename: str, max_age_seconds: int = 60) -> bool:
+        """Verifica se o arquivo de log não foi modificado há muito tempo
+        Returns:
+            type: bool - True se o arquivo estiver 'stale' (não atualizado)
+        """
+        log_path = os.path.join(self.logs_dir, filename)
+
+        if not os.path.exists(log_path):
+            return True
+
+        try:
+            # Pega o timestamp da última modificação do arquivo
+            last_modified = os.path.getmtime(log_path)
+            current_time = time.time()
+
+            # Se o arquivo não foi modificado nos últimos max_age_seconds, considera stale
+            return (current_time - last_modified) > max_age_seconds
+
+        except Exception as e:
+            print(f"Error checking modification time for {filename}: {e}")
+            return True
 
     def get_sensors_messages(self) -> List[Dict]:
         """Obtém mensagens de sensores analisadas a partir dos logs
@@ -173,6 +196,9 @@ class LogService:
                 status[service] = "LOG_CLEARED"
                 continue
 
+            # Verifica se o log está sendo atualizado recentemente
+            is_stale = self._is_log_file_stale(log_file, max_age_seconds=60)
+
             lines = content.strip().split('\n')
             service_status = "UNKNOWN"
 
@@ -202,6 +228,13 @@ class LogService:
 
             if service_status == "UNKNOWN" and lines and any(line.strip() for line in lines):
                 service_status = "STARTING"
+
+            # Se o log está stale (não atualizado) e o último status era RUNNING,
+            # provavelmente o serviço parou de funcionar
+            if is_stale and service_status == "RUNNING":
+                service_status = "STALE"
+            elif is_stale and service_status in ["STARTING", "UNKNOWN"]:
+                service_status = "ERROR"
 
             status[service] = service_status
 

--- a/makefile
+++ b/makefile
@@ -131,6 +131,8 @@ recover-broker:
 	@docker start $(BROKER) || true
 	@echo "$$(date '+%Y-%m-%d %H:%M:%S') [SIMULAÇÃO] Broker $(BROKER) recuperado" >> logs/$(BROKER).log
 	@sleep 5
+	@echo "Reiniciando captura de logs de $(BROKER)..."
+	@nohup docker logs -f $(BROKER) >> logs/$(BROKER).log 2>&1 &
 
 recover-broker-%:
 	@$(MAKE) recover-broker BROKER=$*
@@ -141,6 +143,8 @@ recover-consumer:
 	@docker start $(CONSUMER) || true
 	@echo "$$(date '+%Y-%m-%d %H:%M:%S') [SIMULAÇÃO] Consumer $(CONSUMER) recuperado com sucesso" >> logs/$(CONSUMER).log
 	@sleep 5
+	@echo "Reiniciando captura de logs de $(CONSUMER)..."
+	@nohup docker logs -f $(CONSUMER) >> logs/$(CONSUMER).log 2>&1 &
 
 recover-consumer-%:
 	@$(MAKE) recover-consumer CONSUMER=$*


### PR DESCRIPTION
This pull request updates the log recovery process for both broker and consumer services in the `makefile`. The main improvement is that after restarting either service, the log capturing process is automatically restarted, ensuring that logs continue to be collected without manual intervention.

**Log recovery enhancements:**

* After restarting the broker, the log capture process is restarted using `nohup docker logs -f $(BROKER)`, so logs are appended to `logs/$(BROKER).log` continuously.
* After restarting the consumer, the log capture process is restarted using `nohup docker logs -f $(CONSUMER)`, so logs are appended to `logs/$(CONSUMER).log` continuously.